### PR TITLE
Fix output directory in GitHub Actions deployment workflow by changin…

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -55,6 +55,6 @@ jobs:
         with:
           name: dist-files
       - name: Output Contents
-        run: ls -la dist
+        run: ls -la dist-files
       - name: Deploy to Server
         run: echo "Deploying to Server"


### PR DESCRIPTION
…g 'dist' to 'dist-files' for accurate artifact listing before deployment.