### PR TITLE
Add dependency for error reporting step in GitHub Actions deployment …

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Deploy Site
         run: echo "Deploying..."
   report:
+    needs: [lint, deploy]
     if: failure()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
…workflow to ensure it runs after lint and deploy jobs. This improves the workflow's reliability in handling failures.